### PR TITLE
Update package.json to include the repository

### DIFF
--- a/platforms/darwin-arm64/package.json
+++ b/platforms/darwin-arm64/package.json
@@ -9,6 +9,11 @@
       "postinstall": "chmod u+x ffmpeg",
       "upload": "npm --userconfig=../../.npmrc publish --access public"
     },
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/kribblo/node-ffmpeg-installer.git",
+      "directory": "platforms/darwin-arm64"
+    },
     "keywords": [
       "ffmpeg",
       "binary",

--- a/platforms/darwin-x64/package.json
+++ b/platforms/darwin-x64/package.json
@@ -9,6 +9,11 @@
     "postinstall": "chmod u+x ffmpeg",
     "upload": "npm --userconfig=../../.npmrc publish --access public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kribblo/node-ffmpeg-installer.git",
+    "directory": "platforms/darwin-x64"
+  },
   "keywords": [
     "ffmpeg",
     "binary",

--- a/platforms/linux-arm/package.json
+++ b/platforms/linux-arm/package.json
@@ -9,6 +9,11 @@
     "postinstall": "chmod u+x ffmpeg",
     "upload": "npm --userconfig=../../.npmrc publish --access public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kribblo/node-ffmpeg-installer.git",
+    "directory": "platforms/linux-arm"
+  },
   "keywords": [
     "ffmpeg",
     "binary",

--- a/platforms/linux-arm64/package.json
+++ b/platforms/linux-arm64/package.json
@@ -9,6 +9,11 @@
     "postinstall": "chmod u+x ffmpeg",
     "upload": "npm --userconfig=../../.npmrc publish --access public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kribblo/node-ffmpeg-installer.git",
+    "directory": "platforms/linux-arm64"
+  },
   "keywords": [
     "ffmpeg",
     "binary",

--- a/platforms/linux-ia32/package.json
+++ b/platforms/linux-ia32/package.json
@@ -9,6 +9,11 @@
     "postinstall": "chmod u+x ffmpeg",
     "upload": "npm --userconfig=../../.npmrc publish --access public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kribblo/node-ffmpeg-installer.git",
+    "directory": "platforms/linux-ia32"
+  },
   "keywords": [
     "ffmpeg",
     "binary",

--- a/platforms/linux-x64/package.json
+++ b/platforms/linux-x64/package.json
@@ -9,6 +9,11 @@
     "postinstall": "chmod u+x ffmpeg",
     "upload": "npm --userconfig=../../.npmrc publish --access public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kribblo/node-ffmpeg-installer.git",
+    "directory": "platforms/linux-x64"
+  },
   "keywords": [
     "ffmpeg",
     "binary",

--- a/platforms/win32-ia32/package.json
+++ b/platforms/win32-ia32/package.json
@@ -8,6 +8,11 @@
     "prepublishOnly": "npm test",
     "upload": "npm --userconfig=../../.npmrc publish --access public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kribblo/node-ffmpeg-installer.git",
+    "directory": "platforms/win32-ia32"
+  },
   "keywords": [
     "ffmpeg",
     "binary",

--- a/platforms/win32-x64/package.json
+++ b/platforms/win32-x64/package.json
@@ -8,6 +8,11 @@
     "prepublishOnly": "npm test",
     "upload": "npm --userconfig=../../.npmrc publish --access public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kribblo/node-ffmpeg-installer.git",
+    "directory": "platforms/win32-x64"
+  },
   "keywords": [
     "ffmpeg",
     "binary",


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @ffmpeg-installer/darwin-arm64
* @ffmpeg-installer/darwin-x64
* @ffmpeg-installer/linux-arm
* @ffmpeg-installer/linux-arm64
* @ffmpeg-installer/linux-ia32
* @ffmpeg-installer/linux-x64
* @ffmpeg-installer/win32-ia32
* @ffmpeg-installer/win32-x64